### PR TITLE
Running Virtlyst in Docker Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Don't let your virtualization management use more resources than you main virtua
     --master
 
 # Running with Docker on Linux Mint 19/Ubunt 18.04
+##ToDo
+* Add support for console
+* Streamline process
+
+## Process
 * Make sure Docker is installed  
 * Clone the repo: git clone https://github.com/cutelyst/Virtlyst.git virtlyst
 * Build the image and name it: cd virtlyst; docker -t virtlyst build .

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Don't let your virtualization management use more resources than you main virtua
     --master
 
 # Running with Docker on Linux Mint 19/Ubunt 18.04
-##ToDo
+## ToDo
 * Add support for console
 * Streamline process
 

--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ Don't let your virtualization management use more resources than you main virtua
     --static-map /static=root/static \
     --http-socket localhost:3000 \
     --master
+
+# Running with Docker on Linux Mint 19/Ubunt 18.04
+* Make sure Docker is installed  
+* Clone the repo: git clone https://github.com/cutelyst/Virtlyst.git virtlyst
+* Build the image and name it: cd virtlyst; docker -t virtlyst build .
+* Once the build is done you'll have a image called virtlyst
+* To be able to access the hosts libvirt and the web panel some stuff has to be mapped
+  docker run -ti --name virtlyst -p 3000:3000 -v /run/libvirt:/run/libvirt:rw virtlyst


### PR DESCRIPTION
I created a pull request as I'm not really sure where to start a discussion about the subject. 

This PR  adds some lines to the README to track how I've been able to at least have access to the hosts libvirt environement.

In the end this PR is for discussing the idea of using docker to manage a libvirt host with Virtlyst. 
Using docker-compose might be a better idea.

Can anybody give me an idea what would need to be mapped to the container, to be able to access the console?

Regards

Schnuffle