### PR TITLE
Fix to use Ports in the FQDN / IP field

### DIFF
--- a/src/virtlyst.cpp
+++ b/src/virtlyst.cpp
@@ -272,10 +272,9 @@ void Virtlyst::updateConnections()
         server->password = password;
         server->type     = type;
 
-        
         QStringList parts = hostname.split(":");
-        QString host = parts[0];  // The IP/FQDN part
-        int port = -1;            // Default port value if no port is specified
+        QString host      = parts[0]; // The IP/FQDN part
+        int port          = -1;       // Default port value if no port is specified
 
         // Check if a port was provided
         if (parts.size() > 1) {
@@ -286,7 +285,7 @@ void Virtlyst::updateConnections()
                 port = -1;
             }
         }
-        
+
         QUrl url;
         switch (type) {
         case ServerConn::ConnSocket:
@@ -314,7 +313,6 @@ void Virtlyst::updateConnections()
             break;
         }
         server->url = url;
-
 
         server->conn = new Connection(url, name, server);
         m_connections.insert(id, server);

--- a/src/virtlyst.cpp
+++ b/src/virtlyst.cpp
@@ -272,7 +272,7 @@ void Virtlyst::updateConnections()
         server->password = password;
         server->type     = type;
 
-        QStringList parts = hostname.split(":");
+        QStringList parts = hostname.split(u':');
         QString host      = parts[0]; // The IP/FQDN part
         int port          = -1;       // Default port value if no port is specified
 

--- a/src/virtlyst.cpp
+++ b/src/virtlyst.cpp
@@ -271,6 +271,22 @@ void Virtlyst::updateConnections()
         server->login    = login;
         server->password = password;
         server->type     = type;
+
+        
+        QStringList parts = hostname.split(":");
+        QString host = parts[0];  // The IP/FQDN part
+        int port = -1;            // Default port value if no port is specified
+
+        // Check if a port was provided
+        if (parts.size() > 1) {
+            bool ok;
+            port = parts[1].toInt(&ok);
+            if (!ok) {
+                qCWarning(VIRTLYST) << "Invalid port number in hostname:" << parts[1];
+                port = -1;
+            }
+        }
+        
         QUrl url;
         switch (type) {
         case ServerConn::ConnSocket:
@@ -278,23 +294,27 @@ void Virtlyst::updateConnections()
             break;
         case ServerConn::ConnSSH:
             url = QStringLiteral("qemu+ssh:///system");
-            url.setHost(hostname);
+            url.setHost(host);
+            url.setPort(port);
             url.setUserName(login);
             break;
         case ServerConn::ConnTCP:
             url = QStringLiteral("qemu+tcp:///system");
-            url.setHost(hostname);
+            url.setHost(host);
+            url.setPort(port);
             url.setUserName(login);
             url.setPassword(password);
             break;
         case ServerConn::ConnTLS:
             url = QStringLiteral("qemu+tls:///system");
-            url.setHost(hostname);
+            url.setHost(host);
+            url.setPort(port);
             url.setUserName(login);
             url.setPassword(password);
             break;
         }
         server->url = url;
+
 
         server->conn = new Connection(url, name, server);
         m_connections.insert(id, server);


### PR DESCRIPTION
Correct usage of setHost and setPort of the QUrl class.

Resolving #57 